### PR TITLE
Handle a None version

### DIFF
--- a/spdxshow.py
+++ b/spdxshow.py
@@ -68,7 +68,7 @@ def display_package(pkg, detail=0):
                 if "download_url" in purl.qualifiers:
                     descr = purl.qualifiers["download_url"]
                 else:
-                    version = purl.version
+                    version = purl.version or ''
                     if version.startswith("sha256:"):
                         version = version[: 7 + 5] + "..."
 


### PR DESCRIPTION
I hit this when trying to show the spdx sbom for quay.io/experiment/ralphbean/component-03@sha256:c5754c7494d3039f120951e418b5a73fb2bf0f8ce6c01d3edb2beaa5b28e2728